### PR TITLE
chore: use https repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/kotarac/slicica/issues",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kotarac/slicica.git"
+    "url": "git+https://github.com/kotarac/slicica.git"
   },
   "keywords": [
     "image",


### PR DESCRIPTION
## Summary

- Update `package.json` repository metadata from `git://` to `git+https://`.

## Validation

- Checked the current npm metadata for `slicica@14.0.7`.
- Parsed `package.json` and asserted the updated repository value.
- `git diff --check`
- `git ls-remote https://github.com/kotarac/slicica.git HEAD`
